### PR TITLE
docs: add deployed contract addresses

### DIFF
--- a/content/docs/smart-contracts/deployed-addresses.mdx
+++ b/content/docs/smart-contracts/deployed-addresses.mdx
@@ -1,0 +1,47 @@
+---
+title: Deployed Addresses
+description: Contract addresses for OIF deployments across supported chains
+---
+
+# Deployed Addresses
+
+This page lists the deployed contract addresses for OIF across all supported networks.
+
+<Callout type="info">
+  OIF uses deterministic deployment (CREATE2) for settlement contracts, so addresses are consistent across chains.
+</Callout>
+
+## OIF Settlement Contracts
+
+The core OIF settlement contracts are deployed on all supported mainnets at the same addresses:
+
+| Contract | Address |
+|---|---|
+| **InputSettlerEscrow** | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` |
+| **OutputSettlerSimple** | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+
+### Supported Mainnets
+
+| Chain | InputSettlerEscrow | OutputSettlerSimple |
+|---|---|---|
+| Ethereum | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+| Arbitrum | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+| Base | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+| Linea | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+| Optimism | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+| Scroll | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+| zkSync | `0x15eA18EAcD9C35b454CF1456ed1bD05636B46147` | `0x1DCE289d62C2068584C5D0CFb5C1fD538e832847` |
+
+<Callout type="info">
+  Settlement contracts are not yet deployed on testnets.
+</Callout>
+
+## Broadcaster Infrastructure
+
+For broadcaster contract deployments (broadcaster, receiver, pusher, buffer, provers, and copies), see the [broadcaster deployments repository](https://github.com/openintentsframework/broadcaster/tree/main/deployments).
+
+## Related Docs
+
+- **Core Contracts**: Read about [InputSettlerEscrow and OutputSettler](/docs/smart-contracts/core-contracts) implementations
+- **Deployment Guide**: See the [Deployment Guide](/docs/smart-contracts/deployment) for production deployment procedures
+- **Supporting New Networks**: Learn about [adding new chain support](/docs/smart-contracts/supporting-new-networks)

--- a/content/docs/smart-contracts/meta.json
+++ b/content/docs/smart-contracts/meta.json
@@ -4,6 +4,7 @@
     "overview",
     "quickstart",
     "core-contracts",
+    "deployed-addresses",
     "deployment",
     "supporting-new-networks"
   ]


### PR DESCRIPTION
## Summary
- Adds a new "Deployed Addresses" page under Smart Contracts listing InputSettlerEscrow and OutputSettlerSimple addresses across all 7 supported mainnets
- Links to the [broadcaster deployments repo](https://github.com/openintentsframework/broadcaster/tree/main/deployments) for broadcaster infrastructure contracts
- Adds the page to the sidebar navigation between "Core Contracts" and "Deployment"

## Test plan
- [x] `next build` passes
- [ ] Verify page renders correctly at `/docs/smart-contracts/deployed-addresses`
- [ ] Spot-check addresses against source JSON files in the broadcaster repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new "Deployed Addresses" documentation page listing mainnet settlement contract addresses across supported networks (Ethereum, Arbitrum, Base, Linea, Optimism, Scroll, and zkSync).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->